### PR TITLE
fix: gitignore environment files in project root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,13 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 backend/.env
 backend/.venv
 backend/env/


### PR DESCRIPTION
Re-added environmental files and folders at project root level to .gitignore. We should keep these rules as there might be environmental variables applicable to the entire project in the future. I will merge this as a precaution before anyone accidentally commits env files.