### PR TITLE
Add soil temperature and soil moisture plots to vue frontend

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,18 +2,30 @@
   <h1 id="app">
     <TestComponent />
     <MedianTempGraph />
+    <MeanSoilTempGraph />
+    <MeanSoilMoistureGraph />
+    <AugustMeanSoilTempGraph />
+    <SelectMonthMeanSoilTempGraph />
   </h1>
 </template>
 
 <script>
   import TestComponent from "./components/TestComponent.vue"
-  // import MedianTempGraph from "./components/TestGraphOne.vue"
+  import MedianTempGraph from "./components/TestGraphOne.vue"
+  import MeanSoilTempGraph from "./components/SoilTempGraph.vue"
+  import MeanSoilMoistureGraph from "./components/SoilMoistureGraph.vue"
+  import AugustMeanSoilTempGraph from "./components/AugustSoilTempGraph.vue"
+  import SelectMonthMeanSoilTempGraph from "./components/SelectMonthSoilTempGraph.vue"
 
   export default {
     name: 'App',
     components: {
-      TestComponent,
-      // MedianTempGraph
+      //TestComponent,
+      MedianTempGraph,
+      MeanSoilTempGraph,
+      MeanSoilMoistureGraph,
+      AugustMeanSoilTempGraph,
+      SelectMonthMeanSoilTempGraph
     }
   };
 </script>

--- a/frontend/src/components/AugustSoilTempGraph.vue
+++ b/frontend/src/components/AugustSoilTempGraph.vue
@@ -1,0 +1,102 @@
+<template>
+    <div>
+      <h2>Mean Soil Temperature in August</h2>
+  
+      <!-- Plotly Chart -->
+      <div ref="plotlyChart" style="width: 100%; height: 400px;"></div>
+    </div>
+  </template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import axios from 'axios';
+import Plotly from 'plotly.js-dist-min';
+
+export default {
+  name: 'MeanSoilTempGraph',
+  setup() {
+    const weatherData = ref(null);
+    const plotData = ref([]);
+    const plotlyChart = ref(null);
+
+    const fetchData = async () => {
+      const apiUrl = 'http://localhost:8000/weather/index';
+
+      const params = {
+        weatherVariable: "soil_temperature_0_to_7cm",
+        startDate: new Date('2015-01-01').getTime() / 1000, // Fixed start date
+        endDate: new Date('2023-12-31').getTime() / 1000, // Fixed end date
+        location: "TEMPELHOFER_FELD",
+        temporalResolution: "MONTHLY",
+        aggregation: "MEAN",
+      };
+
+      try {
+        const response = await axios.get(apiUrl, { params });
+        weatherData.value = response.data;
+        processData(response.data);
+        renderPlot();
+      } catch (error) {
+        console.error("Error fetching temperature data:", error);
+      }
+    };
+
+    const processData = (apiResponse) => {
+      if (!apiResponse.data || !Array.isArray(apiResponse.data)) {
+        console.log('Unexpected data format:', apiResponse);
+        return;
+      }
+
+      // Filter for August data (month is 7 since JavaScript months are 0-indexed)
+      const augustData = apiResponse.data.filter(entry => {
+        const date = new Date(entry.timestamp * 1000);
+        return date.getMonth() === 7; // August is month 7
+      });
+
+      // Extract years and temperatures for filtered data
+      const years = augustData.map(entry =>
+        new Date(entry.timestamp * 1000).getFullYear().toString()
+      );
+      const temperatures = augustData.map(entry => entry.value);
+
+      // Update plot data
+      plotData.value = [
+        {
+          x: years,
+          y: temperatures,
+          type: 'bar',
+          name: 'August Soil Temperature',
+          marker: { color: 'darkgreen' }
+        }
+      ];
+    };
+
+    const renderPlot = () => {
+      const layout = {
+        title: 'Mean Soil Temperature for Tempelhofer Feld (2015 - 2023)',
+        xaxis: { title: 'Year', type: 'category' },
+        yaxis: { title: 'Temperature (°C)' },
+        template: 'plotly_white'
+      };
+
+      Plotly.newPlot(plotlyChart.value, plotData.value, layout);
+    };
+
+    onMounted(() => {
+      fetchData();
+    });
+
+    return {
+      weatherData,
+      plotlyChart
+    };
+  }
+};
+</script>
+
+<style scoped>
+h2 {
+  text-align: center;
+  margin-bottom: 10px;
+}
+</style>

--- a/frontend/src/components/SelectMonthSoilTempGraph.vue
+++ b/frontend/src/components/SelectMonthSoilTempGraph.vue
@@ -1,0 +1,146 @@
+<template>
+    <div>
+      <h2>Mean Soil Temperature by Month</h2>
+  
+      <!-- Month Picker -->
+      <div class="date-picker">
+        
+        <label>
+         Select Month:
+          <select v-model="selectedMonth" @change="updateGraph">
+            <option v-for="(month, index) in months" :key="index" :value="index">
+              {{ month }}
+            </option>
+          </select>
+        </label>
+      </div>
+  
+      <!-- Plotly Chart -->
+      <div ref="plotlyChart" style="width: 100%; height: 400px;"></div>
+    </div>
+  </template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import axios from 'axios';
+import Plotly from 'plotly.js-dist-min';
+
+export default {
+  name: 'SelectMonthMeanSoilTempGraph',
+  setup() {
+    const weatherData = ref(null);
+    const startDate = ref('2015-01-01');
+    const endDate = ref('2023-12-31');
+    const selectedMonth = ref(0); // Default to January (0-indexed)
+    const months = ref([
+      'January', 'February', 'March', 'April', 'May', 
+      'June', 'July', 'August', 'September', 
+      'October', 'November', 'December'
+    ]);
+    const plotData = ref([]);
+    const plotlyChart = ref(null);
+
+    const fetchData = async () => {
+      const apiUrl = 'http://localhost:8000/weather/index';
+
+      const params = {
+        weatherVariable: "soil_temperature_0_to_7cm",
+        startDate: new Date(startDate.value).getTime() / 1000,
+        endDate: new Date(endDate.value).getTime() / 1000,
+        location: "TEMPELHOFER_FELD",
+        temporalResolution: "MONTHLY",
+        aggregation: "MEAN",
+      };
+
+      try {
+        const response = await axios.get(apiUrl, { params });
+        weatherData.value = response.data;
+        processData(response.data);
+        renderPlot();
+      } catch (error) {
+        console.error("Error fetching temperature data:", error);
+      }
+    };
+
+    const processData = (apiResponse) => {
+      if (!apiResponse.data || !Array.isArray(apiResponse.data)) {
+        console.log('Unexpected data format:', apiResponse);
+        return;
+      }
+
+      // Filter for the selected month
+      const filteredData = apiResponse.data.filter(entry => {
+        const date = new Date(entry.timestamp * 1000);
+        return date.getMonth() === selectedMonth.value;
+      });
+
+      // Extract years and temperatures for the filtered data
+      const years = filteredData.map(entry =>
+        new Date(entry.timestamp * 1000).getFullYear().toString()
+      );
+      const temperatures = filteredData.map(entry => entry.value);
+
+      // Update plot data
+      plotData.value = [
+        {
+          x: years,
+          y: temperatures,
+          type: 'bar',
+          name: months.value[selectedMonth.value],
+          marker: { color: 'darkgreen' }
+        }
+      ];
+    };
+
+    const renderPlot = () => {
+      const layout = {
+        title: `Mean Soil Temperature in ${months.value[selectedMonth.value]} for Tempelhofer Feld`,
+        xaxis: { title: 'Year', type: 'category' },
+        yaxis: { title: 'Temperature (°C)' },
+        template: 'plotly_white'
+      };
+
+      Plotly.newPlot(plotlyChart.value, plotData.value, layout);
+    };
+
+    const updateGraph = () => {
+      if (startDate.value && endDate.value) {
+        fetchData();
+      }
+    };
+
+    onMounted(() => {
+      fetchData();
+    });
+
+    return {
+      weatherData,
+      startDate,
+      endDate,
+      selectedMonth,
+      months,
+      updateGraph,
+      plotlyChart
+    };
+  }
+};
+</script>
+
+<style scoped>
+h2 {
+  text-align: center;
+  margin-bottom: 10px;
+}
+
+p {
+    text-align: center;
+    margin-bottom: 10px;
+}
+
+.date-picker {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+</style>

--- a/frontend/src/components/SoilMoistureGraph.vue
+++ b/frontend/src/components/SoilMoistureGraph.vue
@@ -1,0 +1,127 @@
+<template>
+    <div>
+      <h2>Mean Monthly Soil Moisture</h2>
+  
+      <!-- Date Range Input Fields -->
+      <div class="date-picker">
+        <label>
+          Start Date:
+          <input type="date" v-model="startDate" @change="updateDateRange" />
+        </label>
+        <label>
+          End Date:
+          <input type="date" v-model="endDate" @change="updateDateRange" />
+        </label>
+      </div>
+  
+      <!-- Plotly Chart -->
+      <div ref="plotlyChart" style="width: 100%; height: 400px;"></div>
+  
+    
+    </div>
+  </template>
+  
+  <script>
+  import { ref, onMounted } from 'vue';
+  import axios from 'axios';
+  import Plotly from 'plotly.js-dist-min';
+  
+  export default {
+    name: 'MeanSoilMoistureGraph',
+    setup() {
+      const weatherData = ref(null);
+      const startDate = ref('2015-01-01');
+      const endDate = ref('2023-12-31');
+      const plotData = ref([]);
+      const plotlyChart = ref(null);
+  
+      const fetchData = async () => {
+        const apiUrl = 'http://localhost:8000/weather/index';
+  
+        const params = {
+          weatherVariable: "soil_temperature_0_to_7cm",
+          startDate: new Date(startDate.value).getTime() / 1000,
+          endDate: new Date(endDate.value).getTime() / 1000,
+          location: "TEMPELHOFER_FELD",
+          temporalResolution: "MONTHLY",
+          aggregation: "MEAN",
+        };
+  
+        try {
+          const response = await axios.get(apiUrl, { params });
+          weatherData.value = response.data;
+          processData(response.data);
+          renderPlot();
+        } catch (error) {
+          console.error("Error fetching temperature data:", error);
+        }
+      };
+  
+      const processData = (apiResponse) => {
+        if (!apiResponse.data || !Array.isArray(apiResponse.data)) {
+          console.log('Unexpected data format:', apiResponse);
+          return;
+        }
+  
+        const dates = apiResponse.data.map(entry =>
+          new Date(entry.timestamp * 1000).toISOString().split('T')[0]
+        );
+        const temperatures = apiResponse.data.map(entry => entry.value);
+  
+        plotData.value = [
+          {
+            x: dates,
+            y: temperatures,
+            type: 'bar',
+            name: 'Moisture',
+            marker: { color: 'green' }
+          }
+        ];
+      };
+  
+      const renderPlot = () => {
+        const layout = {
+          title: 'Mean Monthly Soil Moisture for Tempelhofer Feld (2015 - 2023)',
+          xaxis: { title: '', type: 'date', rangeslider: { visible: true } },
+          yaxis: { title: 'Moisture (m³/m³)' },
+          template: 'plotly_white'
+        };
+  
+        Plotly.newPlot(plotlyChart.value, plotData.value, layout);
+      };
+  
+      const updateDateRange = () => {
+        if (startDate.value && endDate.value) {
+          fetchData();
+        }
+      };
+  
+      onMounted(() => {
+        fetchData();
+      });
+  
+      return {
+        weatherData,
+        startDate,
+        endDate,
+        updateDateRange,
+        plotlyChart
+      };
+    }
+  };
+  </script>
+  
+  <style scoped>
+  h2 {
+    text-align: center;
+    margin-bottom: 10px;
+  }
+  .date-picker {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+  
+  </style>
+  

--- a/frontend/src/components/SoilTempGraph.vue
+++ b/frontend/src/components/SoilTempGraph.vue
@@ -1,0 +1,127 @@
+<template>
+    <div>
+      <h2>Mean Monthly Soil Temperature</h2>
+  
+      <!-- Date Range Input Fields -->
+      <div class="date-picker">
+        <label>
+          Start Date:
+          <input type="date" v-model="startDate" @change="updateDateRange" />
+        </label>
+        <label>
+          End Date:
+          <input type="date" v-model="endDate" @change="updateDateRange" />
+        </label>
+      </div>
+  
+      <!-- Plotly Chart -->
+      <div ref="plotlyChart" style="width: 100%; height: 400px;"></div>
+  
+    
+    </div>
+  </template>
+  
+  <script>
+  import { ref, onMounted } from 'vue';
+  import axios from 'axios';
+  import Plotly from 'plotly.js-dist-min';
+  
+  export default {
+    name: 'MeanSoilTempGraph',
+    setup() {
+      const temperatureData = ref(null);
+      const startDate = ref('2015-01-01');
+      const endDate = ref('2023-12-31');
+      const plotData = ref([]);
+      const plotlyChart = ref(null);
+  
+      const fetchTemperatureData = async () => {
+        const apiUrl = 'http://localhost:8000/weather/index';
+  
+        const params = {
+          weatherVariable: "soil_temperature_0_to_7cm",
+          startDate: new Date(startDate.value).getTime() / 1000,
+          endDate: new Date(endDate.value).getTime() / 1000,
+          location: "TEMPELHOFER_FELD",
+          temporalResolution: "MONTHLY",
+          aggregation: "MEAN",
+        };
+  
+        try {
+          const response = await axios.get(apiUrl, { params });
+          temperatureData.value = response.data;
+          processData(response.data);
+          renderPlot();
+        } catch (error) {
+          console.error("Error fetching temperature data:", error);
+        }
+      };
+  
+      const processData = (apiResponse) => {
+        if (!apiResponse.data || !Array.isArray(apiResponse.data)) {
+          console.log('Unexpected data format:', apiResponse);
+          return;
+        }
+  
+        const dates = apiResponse.data.map(entry =>
+          new Date(entry.timestamp * 1000).toISOString().split('T')[0]
+        );
+        const temperatures = apiResponse.data.map(entry => entry.value);
+  
+        plotData.value = [
+          {
+            x: dates,
+            y: temperatures,
+            type: 'bar',
+            name: 'Temperature',
+            marker: { color: 'blue' }
+          }
+        ];
+      };
+  
+      const renderPlot = () => {
+        const layout = {
+          title: 'Mean Monthly Soil Temperature for Tempelhofer Feld (2015 - 2023)',
+          xaxis: { title: '', type: 'date', rangeslider: { visible: true } },
+          yaxis: { title: 'Temperature (°C)' },
+          template: 'plotly_white'
+        };
+  
+        Plotly.newPlot(plotlyChart.value, plotData.value, layout);
+      };
+  
+      const updateDateRange = () => {
+        if (startDate.value && endDate.value) {
+          fetchTemperatureData();
+        }
+      };
+  
+      onMounted(() => {
+        fetchTemperatureData();
+      });
+  
+      return {
+        temperatureData,
+        startDate,
+        endDate,
+        updateDateRange,
+        plotlyChart
+      };
+    }
+  };
+  </script>
+  
+  <style scoped>
+  h2 {
+    text-align: center;
+    margin-bottom: 10px;
+  }
+  .date-picker {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 20px;
+  }
+  
+  </style>
+  


### PR DESCRIPTION
1. Update TestGraphOne.vue with the right api-url and settings
2. Create bar plots of soil temperature and soil moisture data from 2015 to 2023:
- Mean monthly soil temperature
- Mean monthly soil temperature for August
- Mean monthly soil temperature for each month, selectable via drop-down menu
- Mean monthly soil moisture